### PR TITLE
Group all Dependabot updates per ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,8 +12,16 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
 
   - package-ecosystem: npm
     directory: /
     schedule:
       interval: daily
+    groups:
+      npm:
+        patterns:
+          - "*"


### PR DESCRIPTION
This PR updates the Dependabot configuration to group all updates within each ecosystem into a single pull request, reducing PR noise.

Changes:
- Added a catch-all group for github-actions ecosystem
- Added a catch-all group for 
pm ecosystem